### PR TITLE
Fix SQL table creation order

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -4,6 +4,20 @@ CREATE SCHEMA IF NOT EXISTS image_processing
     AUTHORIZATION gpig;
 
 
+-- Table: image_processing.raw_entry
+
+CREATE TABLE IF NOT EXISTS image_processing.raw_entry
+(
+    image_uri varchar COLLATE pg_catalog."default" NOT NULL,
+    latitude real NOT NULL,
+    longitude real NOT NULL,
+    date timestamp NOT NULL,
+    CONSTRAINT raw_entry_pkey PRIMARY KEY (image_uri)
+);
+
+ALTER TABLE image_processing.raw_entry
+    OWNER to gpig;
+
 -- Table: image_processing.processed_entry
 
 CREATE TABLE IF NOT EXISTS image_processing.processed_entry
@@ -19,19 +33,4 @@ CREATE TABLE IF NOT EXISTS image_processing.processed_entry
 );
 
 ALTER TABLE image_processing.processed_entry
-    OWNER to gpig;
-
-
--- Table: image_processing.raw_entry
-
-CREATE TABLE IF NOT EXISTS image_processing.raw_entry
-(
-    image_uri varchar COLLATE pg_catalog."default" NOT NULL,
-    latitude real NOT NULL,
-    longitude real NOT NULL,
-    date timestamp NOT NULL,
-    CONSTRAINT raw_entry_pkey PRIMARY KEY (image_uri)
-);
-
-ALTER TABLE image_processing.raw_entry
     OWNER to gpig;


### PR DESCRIPTION
`image_processing.processed_entry` has a foreign key to `image_processing.raw_entry`, so `raw_entry` needs to be created before `processed_entry`.