### PR TITLE
Load database config, docker fix

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -39,7 +39,7 @@ app.add_middleware(
 app.mount("/ui", StaticFiles(directory="app/static", html=True), name="static")
 
 # Set up PostgreSQL
-config = load_database_config("config.ini")
+config = load_database_config()
 conn = connect(config)
 
 # Get device for ML

--- a/util/data.py
+++ b/util/data.py
@@ -36,7 +36,7 @@ def load_plant_net_api_key(filename=os.getenv('CONFIG_FILE', "config.ini")):
     return config
 
 
-def load_database_config(filename=os.getenv('CONFIG_FILE', "../config.ini")):
+def load_database_config(filename=os.getenv('CONFIG_FILE', "config.ini")):
     parser = ConfigParser()
     parser.read(filename)
 

--- a/util/data.py
+++ b/util/data.py
@@ -20,7 +20,7 @@ class ProcessedEntry(BaseModel):
 # Database entries end
 
 
-def load_plant_net_api_key(filename=os.getenv('CONFIG_FILE', "../config.ini")):
+def load_plant_net_api_key(filename=os.getenv('CONFIG_FILE', "config.ini")):
     parser = ConfigParser()
     parser.read(filename)
 


### PR DESCRIPTION
@BabarKhanDev Is this the right way of doing for both local and Docker? `load_database_config`'s parameters are `filename=os.getenv('CONFIG_FILE', "../config.ini")`, so that should work locally if CONFIG_FILE isn't set, right?